### PR TITLE
Fixed a bug where pagination would not trigger rerender

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "shurtle-ts",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage": "https://shurtle.app",
   "author": {
     "name": "Dani Hengeveld",

--- a/src/components/create/create-shurtle-form.tsx
+++ b/src/components/create/create-shurtle-form.tsx
@@ -17,7 +17,7 @@ export function CreateShurtleForm() {
   const [showCustomSlug, setShowCustomSlug] = useState(false)
   const [state, formAction, isPending] = useActionState(createShurtle, initialState)
 
-  function handleSubmit(formData: FormData){
+  function handleSubmit(formData: FormData) {
     startTransition(() => formAction(formData))
   }
 
@@ -36,12 +36,11 @@ export function CreateShurtleForm() {
           )}
 
           <div className="space-y-2">
-            <Label htmlFor="url">
+            <Label htmlFor="url-input">
               URL to shorten <span className="text-destructive">*</span>
             </Label>
             <Input
-              id="url"
-              name="url"
+              id="url-input"
               type="url"
               placeholder="https://example.com/very/long/url/that/needs/shortening"
               required
@@ -58,6 +57,7 @@ export function CreateShurtleForm() {
           <Collapsible open={showCustomSlug} onOpenChange={setShowCustomSlug}>
             <CollapsibleTrigger asChild>
               <Button
+                id="toggle-custom-slug"
                 type="button"
                 variant="outline"
                 size="sm"
@@ -77,10 +77,9 @@ export function CreateShurtleForm() {
             </CollapsibleTrigger>
             <CollapsibleContent className="pt-4">
               <div className="space-y-2">
-                <Label htmlFor="slug">Custom slug</Label>
+                <Label htmlFor="custom-slug-input">Custom slug</Label>
                 <Input
-                  id="slug"
-                  name="slug"
+                  id="custom-slug-input"
                   placeholder="my-custom-slug"
                   aria-invalid={!!state.errors?.slug}
                   aria-describedby={state.errors?.slug ? "slug-error" : undefined}
@@ -99,7 +98,7 @@ export function CreateShurtleForm() {
           </Collapsible>
 
           <div className="flex justify-end pt-4">
-            <Button type="submit" disabled={isPending}>
+            <Button id="create-shurtle-btn" type="submit" disabled={isPending}>
               {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               Create Shurtle
             </Button>

--- a/src/components/dashboard/shurtles-section.tsx
+++ b/src/components/dashboard/shurtles-section.tsx
@@ -32,5 +32,10 @@ export async function ShurtlesSection({ searchParams }: ShurtlesSectionProps) {
 
   const { shurtles, totalPages } = await getShurtlesPaginatedCached()
 
-  return <ShurtlesTable shurtles={shurtles} currentPage={page} totalPages={totalPages} perPage={perPage} />
+  return <ShurtlesTable
+    key={`shurtles-table-${page}-${perPage}`}
+    shurtles={shurtles}
+    currentPage={page}
+    totalPages={totalPages}
+    perPage={perPage} />
 }

--- a/src/components/dashboard/shurtles-table.tsx
+++ b/src/components/dashboard/shurtles-table.tsx
@@ -70,11 +70,11 @@ export function ShurtlesTable({ shurtles: initialShurtles, currentPage, totalPag
   }
 
   const handlePageChange = (page: number) => {
-    router.push(`${pathname}?page=${page}&perPage=${perPage}`)
+    router.replace(`${pathname}?page=${page}&perPage=${perPage}`)
   }
 
   const handlePerPageChange = (value: string) => {
-    router.push(`${pathname}?page=1&perPage=${value}`)
+    router.replace(`${pathname}?page=1&perPage=${value}`)
   }
 
   // Generate page numbers to display


### PR DESCRIPTION
This pull request includes updates to improve accessibility, enhance component behavior, and refine navigation logic. Key changes include adding unique IDs for better accessibility, modifying navigation methods to use `router.replace` instead of `router.push`, and updating the `ShurtlesTable` component to ensure proper re-rendering when pagination parameters change.

### Accessibility Improvements:
* Updated `id` attributes in `CreateShurtleForm` for inputs and buttons to improve accessibility (`url` → `url-input`, `slug` → `custom-slug-input`, added `toggle-custom-slug` and `create-shurtle-btn`). [[1]](diffhunk://#diff-fe6a4feecb464939a729d1edff3efacf2d2590eaeec84555444060c01bbce4baL39-R43) [[2]](diffhunk://#diff-fe6a4feecb464939a729d1edff3efacf2d2590eaeec84555444060c01bbce4baR60) [[3]](diffhunk://#diff-fe6a4feecb464939a729d1edff3efacf2d2590eaeec84555444060c01bbce4baL80-R82) [[4]](diffhunk://#diff-fe6a4feecb464939a729d1edff3efacf2d2590eaeec84555444060c01bbce4baL102-R101)

### Component Behavior Enhancements:
* Added a `key` prop to the `ShurtlesTable` component in `ShurtlesSection` to ensure proper re-rendering when `page` or `perPage` changes.

### Navigation Logic Refinements:
* Replaced `router.push` with `router.replace` in `ShurtlesTable` to avoid adding unnecessary entries to the browser history when changing pages or items per page.

### Version Update:
* Incremented the package version from `1.1.0` to `1.1.1` in `package.json`.